### PR TITLE
Adds support for testing a graphql endpoint

### DIFF
--- a/src/ango/settings/dev.py
+++ b/src/ango/settings/dev.py
@@ -4,6 +4,7 @@ SECRET_KEY = 'ojk@86z9*$zyuhge#3)p*%$q0psoo2lq*tv9jw90#1eezcl^y2'
 
 DEBUG = True
 
+MIDDLEWARE.remove('django.middleware.csrf.CsrfViewMiddleware')
 
 DATABASES = {
     'default': {

--- a/src/todos/readme.md
+++ b/src/todos/readme.md
@@ -1,0 +1,64 @@
+# Todos App
+You may use graphiql or curl to try out some of the queries.
+
+## Queries
+The following is an example query to get the first ten todos and
+return the id and text of each one.
+```
+query {
+  allTodos(first: 10){
+    edges{
+      node{
+        id,
+        text
+      }
+    }
+  }
+}
+```
+The response
+```
+{
+  "data": {
+    "allTodos": {
+      "edges": [
+        {
+          "node": {
+            "id": "VG9kb05vZGU6MQ==",
+            "text": "adfasdfdsa"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Queries with Variables
+```
+query getSomeTodos($todos_count: Int!) {
+  allTodos(first: $todos_count) {
+    edges {
+      node {
+        id
+        text
+      }
+    }
+  }
+}
+```
+
+### Using Curl
+The actual post request is a json string to be careful of empty space or new lines.
+Running the example query again would look like this
+```
+curl -XPOST -H 'Content-Type:application/graphql'  \
+    -d '{ allTodos(first: 10){edges{node{id,text}}}}' \
+    http://localhost:8000/graphql
+```
+And return the following data.
+```
+{"data":{"allTodos":{"edges":[{"node":{"id":"VG9kb05vZGU6MQ==","text":"adsfasdfasdfsd"}},{"node":{"id":"VG9kb05vZGU6Mg==","text":"adsfadsfa"}}]}}}
+
+```
+## Mutations

--- a/src/todos/readme.md
+++ b/src/todos/readme.md
@@ -61,4 +61,11 @@ And return the following data.
 {"data":{"allTodos":{"edges":[{"node":{"id":"VG9kb05vZGU6MQ==","text":"adsfasdfasdfsd"}},{"node":{"id":"VG9kb05vZGU6Mg==","text":"adsfadsfa"}}]}}}
 
 ```
+
+### Using CocoaRestClient GUI /JSON Body
+This is a valid json body you can paste into the raw input of the coca rest client.
+`{"query": "query {allTodos(first: 10){edges{node{id,text}}}}"}`
+
 ## Mutations
+
+

--- a/src/todos/tests.py
+++ b/src/todos/tests.py
@@ -19,12 +19,14 @@ class TodoTest(TestCase):
 
         TodoModel.objects.create(user=self.user, text="My todo")
 
-    def test_todo_created_was_created(self):
+    def test_all_todos_graphql_endpoint(self):
+        """Test all_todos graphql query"""
+
+        # Sanity Checks
         todo = TodoModel.objects.get(text="My todo")
         self.assertEqual(todo.text, 'My todo')
 
-    def test_all_todos_graphql_endpoint(self):
-        """Test all_todos graphql query"""
+        # Setup query and response
         query = {
             "query": "query {allTodos(first: 10){edges{node{id,text}}}}"
         }
@@ -40,9 +42,10 @@ class TodoTest(TestCase):
                     ]}
             }
         }
+        # Make the post request
         c = Client()
         response = c.post('/graphql', query)
+
         # Decode byte code response.content and load the json
         graphql_response = json.loads(response.content.decode('ascii'))
-        print(graphql_response)
         self.assertEqual(graphql_response, expected_response)

--- a/src/todos/tests.py
+++ b/src/todos/tests.py
@@ -1,5 +1,8 @@
+import json
 from django.contrib.auth.models import User
 from django.test import TestCase, RequestFactory
+from django.http import JsonResponse
+
 from .models import TodoModel
 
 
@@ -14,7 +17,8 @@ class TodoTest(TestCase):
             password='top_secret'
         )
 
-        TodoModel.objects.create(user=self.user, text="roar")
+        TodoModel.objects.create(user=self.user, text="My todo")
 
-    def test_animals_can_speak(self):
-        todo = TodoModel.objects.get(text="roar")
+    def test_todo_created_was_created(self):
+        todo = TodoModel.objects.get(text="My todo")
+        self.assertEqual(todo.text, 'My todo')

--- a/src/todos/tests.py
+++ b/src/todos/tests.py
@@ -1,7 +1,7 @@
 import json
+
 from django.contrib.auth.models import User
-from django.test import TestCase, RequestFactory
-from django.http import JsonResponse
+from django.test import TestCase, Client
 
 from .models import TodoModel
 
@@ -22,3 +22,27 @@ class TodoTest(TestCase):
     def test_todo_created_was_created(self):
         todo = TodoModel.objects.get(text="My todo")
         self.assertEqual(todo.text, 'My todo')
+
+    def test_all_todos_graphql_endpoint(self):
+        """Test all_todos graphql query"""
+        query = {
+            "query": "query {allTodos(first: 10){edges{node{id,text}}}}"
+        }
+        expected_response = {
+            "data": {
+                "allTodos": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "VG9kb05vZGU6MQ==",
+                                "text": "My todo"
+                            }}
+                    ]}
+            }
+        }
+        c = Client()
+        response = c.post('/graphql', query)
+        # Decode byte code response.content and load the json
+        graphql_response = json.loads(response.content.decode('ascii'))
+        print(graphql_response)
+        self.assertEqual(graphql_response, expected_response)


### PR DESCRIPTION
* adds a bit of documentation to the todos app for quick lookups of interacting the the graphql endpoint and todos schema.

* cleans up and consolidates tests.