### PR TITLE
Adds coverage support to the circle.yml file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,12 @@
 machine:
   python:
     version: 3.5.2
+general:
+  artifacts:
+    - ".coverage"
 dependencies:
   post:
     - pip install -r ./deps/testing.txt
 test:
   override:
-    - ./src/manage.py test ./src
+    - coverage run --source='.' ./src/manage.py test ./src


### PR DESCRIPTION
This pull request should integrate coverage.py and give an example of how to see which files are covered in additon to saving the .coverage file in the circle ci artifacts directory.